### PR TITLE
Implement payment success flow and admin panel

### DIFF
--- a/crypto_pay.py
+++ b/crypto_pay.py
@@ -17,3 +17,17 @@ async def create_invoice(amount: float, currency: str = "USD"):
                 return await resp.json()
             except Exception:
                 return {"ok": False}
+
+async def get_invoice(invoice_id: int):
+    headers = {"Crypto-Pay-API-Token": CRYPTO_PAY_TOKEN}
+    params = {"invoice_ids": invoice_id}
+    async with aiohttp.ClientSession() as session:
+        async with session.get(f"{API_URL}/getInvoices", params=params, headers=headers) as resp:
+            try:
+                data = await resp.json()
+            except Exception:
+                return None
+            if not data.get("ok"):
+                return None
+            items = data.get("result", {}).get("items", [])
+            return items[0] if items else None

--- a/db.py
+++ b/db.py
@@ -1,30 +1,166 @@
 import json
 import os
+from typing import Any, Dict, List, Optional
 
 DB_FILE = "db.json"
 
-def load_db():
-    if not os.path.exists(DB_FILE):
-        return {}
-    with open(DB_FILE, "r", encoding="utf-8") as f:
-        return json.load(f)
+DEFAULT_DB: Dict[str, Any] = {
+    "users": {},
+    "settings": {
+        "topup_enabled": True,
+        "disabled_operators": [],
+    },
+    "invoices": {},
+    "next_purchase_id": 1,
+}
 
-def save_db(data):
+def load_db() -> Dict[str, Any]:
+    if not os.path.exists(DB_FILE):
+        return json.loads(json.dumps(DEFAULT_DB))
+    with open(DB_FILE, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    for k, v in DEFAULT_DB.items():
+        if k not in data:
+            data[k] = v if not isinstance(v, dict) else json.loads(json.dumps(v))
+    return data
+
+def save_db(data: Dict[str, Any]) -> None:
     with open(DB_FILE, "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=2)
 
+def ensure_user(user_id: int) -> Dict[str, Any]:
+    data = load_db()
+    user = data["users"].setdefault(
+        str(user_id), {"balance": 0.0, "banned": False, "purchases": []}
+    )
+    save_db(data)
+    return user
+
 def get_balance(user_id: int) -> float:
     data = load_db()
-    return data.get(str(user_id), {}).get("balance", 0.0)
+    return (
+        data["users"].get(str(user_id), {}).get("balance", 0.0)
+    )
 
 def add_balance(user_id: int, amount: float) -> None:
     data = load_db()
-    user = data.setdefault(str(user_id), {"balance": 0.0})
+    user = data["users"].setdefault(
+        str(user_id), {"balance": 0.0, "banned": False, "purchases": []}
+    )
     user["balance"] += amount
     save_db(data)
 
 def deduct_balance(user_id: int, amount: float) -> None:
     data = load_db()
-    user = data.setdefault(str(user_id), {"balance": 0.0})
+    user = data["users"].setdefault(
+        str(user_id), {"balance": 0.0, "banned": False, "purchases": []}
+    )
     user["balance"] = max(0.0, user["balance"] - amount)
     save_db(data)
+
+def set_ban(user_id: int, banned: bool) -> None:
+    data = load_db()
+    user = data["users"].setdefault(
+        str(user_id), {"balance": 0.0, "banned": False, "purchases": []}
+    )
+    user["banned"] = banned
+    save_db(data)
+
+def is_banned(user_id: int) -> bool:
+    data = load_db()
+    return data["users"].get(str(user_id), {}).get("banned", False)
+
+def get_all_users() -> List[int]:
+    data = load_db()
+    return [int(uid) for uid in data["users"].keys()]
+
+def add_purchase(user_id: int, info: Dict[str, Any]) -> int:
+    data = load_db()
+    user = data["users"].setdefault(
+        str(user_id), {"balance": 0.0, "banned": False, "purchases": []}
+    )
+    purchase_id = data.get("next_purchase_id", 1)
+    info.update({"id": purchase_id, "status": info.get("status", "pending")})
+    user["purchases"].append(info)
+    data["next_purchase_id"] = purchase_id + 1
+    save_db(data)
+    return purchase_id
+
+def update_purchase_status(user_id: int, purchase_id: int, status: str) -> None:
+    data = load_db()
+    user = data["users"].get(str(user_id))
+    if not user:
+        return
+    for p in user.get("purchases", []):
+        if p.get("id") == purchase_id:
+            p["status"] = status
+            break
+    save_db(data)
+
+def get_all_purchases() -> List[Dict[str, Any]]:
+    data = load_db()
+    res = []
+    for uid, udata in data["users"].items():
+        for p in udata.get("purchases", []):
+            item = p.copy()
+            item["user_id"] = int(uid)
+            res.append(item)
+    return res
+
+def get_purchase_by_id(purchase_id: int) -> Optional[Dict[str, Any]]:
+    data = load_db()
+    for uid, udata in data["users"].items():
+        for p in udata.get("purchases", []):
+            if p.get("id") == purchase_id:
+                item = p.copy()
+                item["user_id"] = int(uid)
+                return item
+    return None
+
+
+def get_user_purchases(user_id: int) -> List[Dict[str, Any]]:
+    data = load_db()
+    user = data["users"].get(str(user_id), {})
+    return user.get("purchases", [])
+
+def add_invoice(invoice_id: int, info: Dict[str, Any]) -> None:
+    data = load_db()
+    data["invoices"][str(invoice_id)] = info
+    save_db(data)
+
+def get_invoice(invoice_id: int) -> Optional[Dict[str, Any]]:
+    data = load_db()
+    return data["invoices"].get(str(invoice_id))
+
+def remove_invoice(invoice_id: int) -> None:
+    data = load_db()
+    data["invoices"].pop(str(invoice_id), None)
+    save_db(data)
+
+def is_topup_enabled() -> bool:
+    data = load_db()
+    return data["settings"].get("topup_enabled", True)
+
+def set_topup_enabled(value: bool) -> None:
+    data = load_db()
+    data["settings"]["topup_enabled"] = value
+    save_db(data)
+
+def disable_operator(operator: str) -> None:
+    data = load_db()
+    ops = data["settings"].setdefault("disabled_operators", [])
+    if operator not in ops:
+        ops.append(operator)
+    save_db(data)
+
+def enable_operator(operator: str) -> None:
+    data = load_db()
+    ops = data["settings"].setdefault("disabled_operators", [])
+    if operator in ops:
+        ops.remove(operator)
+    save_db(data)
+
+def is_operator_enabled(operator: str) -> bool:
+    data = load_db()
+    ops = data["settings"].get("disabled_operators", [])
+    return operator not in ops

--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -1,0 +1,188 @@
+from aiogram import types
+from aiogram.dispatcher import FSMContext
+from aiogram.dispatcher.filters.state import State, StatesGroup
+
+from loader import dp, ADMIN_ID, bot
+from keyboards import admin_keyboard, topup_control_keyboard
+from db import (
+    set_ban,
+    is_banned,
+    get_all_users,
+    get_all_purchases,
+    is_topup_enabled,
+    set_topup_enabled,
+    disable_operator,
+    enable_operator,
+    is_operator_enabled,
+)
+
+
+class Broadcast(StatesGroup):
+    waiting_for_content = State()
+
+
+class BanUser(StatesGroup):
+    waiting_for_user_id = State()
+
+
+class OperatorControl(StatesGroup):
+    waiting_for_name = State()
+
+
+@dp.message_handler(commands=["admin"])
+async def admin_panel(message: types.Message):
+    if message.from_user.id != ADMIN_ID:
+        return
+    await message.answer("Админ панель", reply_markup=admin_keyboard())
+
+
+@dp.callback_query_handler(lambda c: c.data == "admin_broadcast")
+async def admin_broadcast(callback_query: types.CallbackQuery):
+    if callback_query.from_user.id != ADMIN_ID:
+        await callback_query.answer("Нет доступа", show_alert=True)
+        return
+    await callback_query.message.answer("Отправьте сообщение или фото для рассылки:")
+    await Broadcast.waiting_for_content.set()
+    await callback_query.answer()
+
+
+@dp.message_handler(state=Broadcast.waiting_for_content, content_types=types.ContentTypes.ANY)
+async def process_broadcast(message: types.Message, state: FSMContext):
+    if message.from_user.id != ADMIN_ID:
+        return
+    users = get_all_users()
+    if message.content_type == types.ContentType.PHOTO:
+        file_id = message.photo[-1].file_id
+        caption = message.caption or ""
+        for uid in users:
+            try:
+                await bot.send_photo(uid, file_id, caption)
+            except Exception:
+                pass
+    else:
+        text = message.text or ""
+        for uid in users:
+            try:
+                await bot.send_message(uid, text)
+            except Exception:
+                pass
+    await message.answer("Рассылка завершена", reply_markup=admin_keyboard())
+    await state.finish()
+
+
+@dp.callback_query_handler(lambda c: c.data == "admin_ban")
+async def admin_ban_start(callback_query: types.CallbackQuery):
+    if callback_query.from_user.id != ADMIN_ID:
+        await callback_query.answer("Нет доступа", show_alert=True)
+        return
+    await callback_query.message.answer("Введите ID пользователя:")
+    await BanUser.waiting_for_user_id.set()
+    await callback_query.answer()
+
+
+@dp.message_handler(state=BanUser.waiting_for_user_id)
+async def process_ban(message: types.Message, state: FSMContext):
+    if message.from_user.id != ADMIN_ID:
+        return
+    try:
+        user_id = int(message.text)
+    except ValueError:
+        await message.answer("Введите корректный ID:")
+        return
+    if is_banned(user_id):
+        set_ban(user_id, False)
+        await message.answer("Пользователь разбанен", reply_markup=admin_keyboard())
+    else:
+        set_ban(user_id, True)
+        await message.answer("Пользователь забанен", reply_markup=admin_keyboard())
+    await state.finish()
+
+
+@dp.callback_query_handler(lambda c: c.data == "admin_purchases")
+async def admin_purchases(callback_query: types.CallbackQuery):
+    if callback_query.from_user.id != ADMIN_ID:
+        await callback_query.answer("Нет доступа", show_alert=True)
+        return
+    purchases = get_all_purchases()
+    if not purchases:
+        text = "Покупок нет."
+    else:
+        text = "\n".join(
+            [
+                f"#{p['id']} user {p['user_id']} {p.get('operator', '-')} {p.get('phone', '-')} {p['amount']}$ {p['status']}"
+                for p in purchases
+            ]
+        )
+    await callback_query.message.answer(text)
+    await callback_query.answer()
+
+
+@dp.callback_query_handler(lambda c: c.data == "admin_users")
+async def admin_users(callback_query: types.CallbackQuery):
+    if callback_query.from_user.id != ADMIN_ID:
+        await callback_query.answer("Нет доступа", show_alert=True)
+        return
+    users = get_all_users()
+    text = "Всего пользователей: {}\n{}".format(len(users), "\n".join(map(str, users)))
+    await callback_query.message.answer(text)
+    await callback_query.answer()
+
+
+@dp.callback_query_handler(lambda c: c.data == "admin_topups")
+async def admin_topups(callback_query: types.CallbackQuery):
+    if callback_query.from_user.id != ADMIN_ID:
+        await callback_query.answer("Нет доступа", show_alert=True)
+        return
+    enabled = is_topup_enabled()
+    await callback_query.message.answer(
+        "Управление пополнениями", reply_markup=topup_control_keyboard(enabled)
+    )
+    await callback_query.answer()
+
+
+@dp.callback_query_handler(lambda c: c.data == "topup_stop_all")
+async def topup_stop_all(callback_query: types.CallbackQuery):
+    if callback_query.from_user.id != ADMIN_ID:
+        await callback_query.answer("Нет доступа", show_alert=True)
+        return
+    set_topup_enabled(False)
+    await callback_query.message.answer("Пополнения остановлены", reply_markup=admin_keyboard())
+    await callback_query.answer()
+
+
+@dp.callback_query_handler(lambda c: c.data == "topup_enable_all")
+async def topup_enable_all(callback_query: types.CallbackQuery):
+    if callback_query.from_user.id != ADMIN_ID:
+        await callback_query.answer("Нет доступа", show_alert=True)
+        return
+    set_topup_enabled(True)
+    await callback_query.message.answer("Пополнения возобновлены", reply_markup=admin_keyboard())
+    await callback_query.answer()
+
+
+@dp.callback_query_handler(lambda c: c.data == "topup_toggle_operator")
+async def topup_toggle_operator(callback_query: types.CallbackQuery):
+    if callback_query.from_user.id != ADMIN_ID:
+        await callback_query.answer("Нет доступа", show_alert=True)
+        return
+    await callback_query.message.answer("Введите название оператора:")
+    await OperatorControl.waiting_for_name.set()
+    await callback_query.answer()
+
+
+@dp.message_handler(state=OperatorControl.waiting_for_name)
+async def process_operator_toggle(message: types.Message, state: FSMContext):
+    if message.from_user.id != ADMIN_ID:
+        return
+    op = message.text.strip()
+    if is_operator_enabled(op):
+        disable_operator(op)
+        await message.answer(
+            f"Оператор {op} отключен", reply_markup=admin_keyboard()
+        )
+    else:
+        enable_operator(op)
+        await message.answer(
+            f"Оператор {op} включен", reply_markup=admin_keyboard()
+        )
+    await state.finish()

--- a/handlers/topup.py
+++ b/handlers/topup.py
@@ -1,16 +1,31 @@
 from aiogram import types
 from aiogram.dispatcher import FSMContext
 from aiogram.dispatcher.filters.state import State, StatesGroup
+from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 
-from loader import dp
+from loader import dp, bot, ADMIN_ID
 from utils import is_subscribed
 from keyboards import (
     subscribe_keyboard,
     back_keyboard,
     operators_keyboard,
 )
-from db import get_balance, deduct_balance
-from crypto_pay import create_invoice
+from db import (
+    get_balance,
+    deduct_balance,
+    add_balance,
+    add_invoice,
+    get_invoice as db_get_invoice,
+    remove_invoice,
+    add_purchase,
+    update_purchase_status,
+    get_purchase_by_id,
+    is_topup_enabled,
+    is_operator_enabled,
+    is_banned,
+    ensure_user,
+)
+from crypto_pay import create_invoice, get_invoice as crypto_get_invoice
 
 class TopupSim(StatesGroup):
     waiting_for_phone = State()
@@ -22,12 +37,21 @@ class TopupBalance(StatesGroup):
 
 @dp.callback_query_handler(lambda c: c.data == "topup_sim")
 async def topup_sim_start(callback_query: types.CallbackQuery, state: FSMContext):
-    if not await is_subscribed(callback_query.from_user.id):
+    user_id = callback_query.from_user.id
+    if is_banned(user_id):
+        await callback_query.answer("Вы забанены", show_alert=True)
+        return
+    if not await is_subscribed(user_id):
         await callback_query.message.answer(
             "Пожалуйста, подпишитесь на канал:",
             reply_markup=subscribe_keyboard(),
         )
         return
+    if not is_topup_enabled():
+        await callback_query.message.answer("Пополнения временно остановлены.")
+        await callback_query.answer()
+        return
+    ensure_user(user_id)
     await callback_query.answer()
     await callback_query.message.answer("Введите ваш номер:")
     await TopupSim.waiting_for_phone.set()
@@ -43,6 +67,11 @@ async def process_phone(message: types.Message, state: FSMContext):
 @dp.callback_query_handler(lambda c: c.data.startswith("op_"), state=TopupSim.waiting_for_operator)
 async def process_operator(callback_query: types.CallbackQuery, state: FSMContext):
     operator = callback_query.data.split("_", 1)[1]
+    if not is_operator_enabled(operator):
+        await callback_query.message.answer("Пополнение по данному оператору недоступно.")
+        await callback_query.answer()
+        await state.finish()
+        return
     await state.update_data(operator=operator)
     await callback_query.message.answer("Введите сумму пополнения (в $):")
     await callback_query.answer()
@@ -55,17 +84,41 @@ async def process_amount_sim(message: types.Message, state: FSMContext):
     except ValueError:
         await message.answer("Введите корректную сумму:")
         return
-    balance = get_balance(message.from_user.id)
+    user_id = message.from_user.id
+    data = await state.get_data()
+    phone = data.get("phone")
+    operator = data.get("operator")
+    balance = get_balance(user_id)
     if balance >= amount:
-        deduct_balance(message.from_user.id, amount)
+        deduct_balance(user_id, amount)
+        add_purchase(user_id, {
+            "phone": phone,
+            "operator": operator,
+            "amount": amount,
+            "status": "completed",
+        })
         await message.answer("СИМ успешно пополнена.", reply_markup=back_keyboard())
     else:
         invoice = await create_invoice(amount)
         if invoice.get("ok"):
-            url = invoice["result"].get("pay_url", "")
+            result = invoice["result"]
+            url = result.get("pay_url", "")
+            invoice_id = result.get("invoice_id")
+            add_invoice(invoice_id, {
+                "type": "sim",
+                "user_id": user_id,
+                "phone": phone,
+                "operator": operator,
+                "amount": amount,
+            })
+            kb = InlineKeyboardMarkup(row_width=1)
+            kb.add(
+                InlineKeyboardButton("Я оплатил", callback_data=f"check_invoice_{invoice_id}"),
+                InlineKeyboardButton("🔙 Назад", callback_data="back"),
+            )
             await message.answer(
                 f"Недостаточно средств. Оплатите счёт: {url}",
-                reply_markup=back_keyboard(),
+                reply_markup=kb,
             )
         else:
             await message.answer(
@@ -76,12 +129,21 @@ async def process_amount_sim(message: types.Message, state: FSMContext):
 
 @dp.callback_query_handler(lambda c: c.data == "topup_balance")
 async def topup_balance_start(callback_query: types.CallbackQuery):
-    if not await is_subscribed(callback_query.from_user.id):
+    user_id = callback_query.from_user.id
+    if is_banned(user_id):
+        await callback_query.answer("Вы забанены", show_alert=True)
+        return
+    if not await is_subscribed(user_id):
         await callback_query.message.answer(
             "Пожалуйста, подпишитесь на канал:",
             reply_markup=subscribe_keyboard(),
         )
         return
+    if not is_topup_enabled():
+        await callback_query.message.answer("Пополнения временно остановлены.")
+        await callback_query.answer()
+        return
+    ensure_user(user_id)
     await callback_query.answer()
     await callback_query.message.answer("Введите сумму пополнения баланса (в $):")
     await TopupBalance.waiting_for_amount.set()
@@ -95,10 +157,22 @@ async def process_amount_balance(message: types.Message, state: FSMContext):
         return
     invoice = await create_invoice(amount)
     if invoice.get("ok"):
-        url = invoice["result"].get("pay_url", "")
+        result = invoice["result"]
+        url = result.get("pay_url", "")
+        invoice_id = result.get("invoice_id")
+        add_invoice(invoice_id, {
+            "type": "balance",
+            "user_id": message.from_user.id,
+            "amount": amount,
+        })
+        kb = InlineKeyboardMarkup(row_width=1)
+        kb.add(
+            InlineKeyboardButton("Я оплатил", callback_data=f"check_invoice_{invoice_id}"),
+            InlineKeyboardButton("🔙 Назад", callback_data="back"),
+        )
         await message.answer(
             f"Оплатите счёт для пополнения баланса: {url}",
-            reply_markup=back_keyboard(),
+            reply_markup=kb,
         )
     else:
         await message.answer(
@@ -106,3 +180,82 @@ async def process_amount_balance(message: types.Message, state: FSMContext):
             reply_markup=back_keyboard(),
         )
     await state.finish()
+
+
+@dp.callback_query_handler(lambda c: c.data.startswith("check_invoice_"))
+async def check_invoice_callback(callback_query: types.CallbackQuery):
+    invoice_id = int(callback_query.data.split("_", 2)[2])
+    info = db_get_invoice(invoice_id)
+    if not info:
+        await callback_query.answer("Счёт не найден", show_alert=True)
+        return
+    invoice = await crypto_get_invoice(invoice_id)
+    if invoice and invoice.get("status") == "paid":
+        remove_invoice(invoice_id)
+        user_id = info["user_id"]
+        amount = info["amount"]
+        if info["type"] == "balance":
+            add_balance(user_id, amount)
+            await callback_query.message.answer(f"Баланс пополнен на {amount} $")
+        else:
+            purchase_id = add_purchase(user_id, {
+                "phone": info["phone"],
+                "operator": info["operator"],
+                "amount": amount,
+                "status": "pending",
+            })
+            text = (
+                f"Пользователь: {user_id}\n"
+                f"Номер: {info['phone']}\n"
+                f"Оператор: {info['operator']}\n"
+                f"Сумма: {amount} $"
+            )
+            kb = InlineKeyboardMarkup(row_width=1)
+            kb.add(
+                InlineKeyboardButton("Пополнено", callback_data=f"admin_confirm_{purchase_id}"),
+                InlineKeyboardButton("Отмена", callback_data=f"admin_cancel_{purchase_id}"),
+            )
+            await bot.send_message(ADMIN_ID, text, reply_markup=kb)
+            await callback_query.message.answer("Платёж получен, ожидайте пополнения")
+        await callback_query.answer()
+    else:
+        await callback_query.answer("Платёж не найден", show_alert=True)
+
+
+@dp.callback_query_handler(lambda c: c.data.startswith("admin_confirm_"))
+async def admin_confirm(callback_query: types.CallbackQuery):
+    if callback_query.from_user.id != ADMIN_ID:
+        await callback_query.answer("Нет доступа", show_alert=True)
+        return
+    purchase_id = int(callback_query.data.split("_", 2)[2])
+    purchase = get_purchase_by_id(purchase_id)
+    if not purchase:
+        await callback_query.answer("Не найдено", show_alert=True)
+        return
+    update_purchase_status(purchase["user_id"], purchase_id, "completed")
+    await bot.send_message(
+        purchase["user_id"],
+        f"Ваш номер {purchase['phone']} пополнен на {purchase['amount']} $",
+    )
+    await callback_query.message.edit_text("Помечено как пополнено")
+    await callback_query.answer()
+
+
+@dp.callback_query_handler(lambda c: c.data.startswith("admin_cancel_"))
+async def admin_cancel(callback_query: types.CallbackQuery):
+    if callback_query.from_user.id != ADMIN_ID:
+        await callback_query.answer("Нет доступа", show_alert=True)
+        return
+    purchase_id = int(callback_query.data.split("_", 2)[2])
+    purchase = get_purchase_by_id(purchase_id)
+    if not purchase:
+        await callback_query.answer("Не найдено", show_alert=True)
+        return
+    update_purchase_status(purchase["user_id"], purchase_id, "canceled")
+    add_balance(purchase["user_id"], purchase["amount"])
+    await bot.send_message(
+        purchase["user_id"],
+        f"Пополнение отменено, {purchase['amount']} $ возвращено на баланс",
+    )
+    await callback_query.message.edit_text("Отменено и возвращено")
+    await callback_query.answer()

--- a/keyboards.py
+++ b/keyboards.py
@@ -35,3 +35,25 @@ def operators_keyboard() -> InlineKeyboardMarkup:
         InlineKeyboardButton("Йота", callback_data="op_Йота"),
     )
     return kb
+
+
+def admin_keyboard() -> InlineKeyboardMarkup:
+    kb = InlineKeyboardMarkup(row_width=2)
+    kb.add(
+        InlineKeyboardButton("📢 Рассылка", callback_data="admin_broadcast"),
+        InlineKeyboardButton("🚫 Бан пользователя", callback_data="admin_ban"),
+        InlineKeyboardButton("📦 Все покупки", callback_data="admin_purchases"),
+        InlineKeyboardButton("👥 Все пользователи", callback_data="admin_users"),
+        InlineKeyboardButton("⛔ Остановить пополнения", callback_data="admin_topups"),
+    )
+    return kb
+
+
+def topup_control_keyboard(enabled: bool) -> InlineKeyboardMarkup:
+    kb = InlineKeyboardMarkup(row_width=1)
+    if enabled:
+        kb.add(InlineKeyboardButton("Остановить все", callback_data="topup_stop_all"))
+    else:
+        kb.add(InlineKeyboardButton("Возобновить все", callback_data="topup_enable_all"))
+    kb.add(InlineKeyboardButton("Остановить/включить оператора", callback_data="topup_toggle_operator"))
+    return kb

--- a/loader.py
+++ b/loader.py
@@ -6,6 +6,7 @@ BOT_TOKEN = os.getenv("BOT_TOKEN")
 CHANNEL_ID = os.getenv("CHANNEL_ID", "@example_channel")
 CHANNEL_LINK = os.getenv("CHANNEL_LINK", "https://t.me/example_channel")
 CRYPTO_PAY_TOKEN = os.getenv("CRYPTO_PAY_TOKEN")
+ADMIN_ID = int(os.getenv("ADMIN_ID", "0"))
 
 bot = Bot(token=BOT_TOKEN, parse_mode="HTML")
 storage = MemoryStorage()

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from loader import dp
 from utils import fetch_bot_name
 import handlers.start  # noqa: F401
 import handlers.topup  # noqa: F401
+import handlers.admin  # noqa: F401
 
 async def on_startup(dispatcher):
     await fetch_bot_name()


### PR DESCRIPTION
## Summary
- expand database to track users, purchases, invoices and operator settings
- handle invoice payments with admin confirmation or refund
- add admin panel for broadcasts, bans, user/purchase lists and top-up controls

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689f2fd18bc8832b81f84f87aa6138f4