### PR TITLE
Add admin rate control and bottom reply menu

### DIFF
--- a/db.py
+++ b/db.py
@@ -9,6 +9,7 @@ DEFAULT_DB: Dict[str, Any] = {
     "settings": {
         "topup_enabled": True,
         "disabled_operators": [],
+        "rate": 0.0,
     },
     "invoices": {},
     "next_purchase_id": 1,
@@ -144,6 +145,17 @@ def is_topup_enabled() -> bool:
 def set_topup_enabled(value: bool) -> None:
     data = load_db()
     data["settings"]["topup_enabled"] = value
+    save_db(data)
+
+
+def get_rate() -> float:
+    data = load_db()
+    return data["settings"].get("rate", 0.0)
+
+
+def set_rate(value: float) -> None:
+    data = load_db()
+    data["settings"]["rate"] = value
     save_db(data)
 
 def disable_operator(operator: str) -> None:

--- a/handlers/topup.py
+++ b/handlers/topup.py
@@ -52,6 +52,25 @@ async def topup_sim_start(callback_query: types.CallbackQuery, state: FSMContext
     await state.set_state(TopupSim.waiting_for_phone)
 
 
+@router.message(F.text == "📱 Пополнить СИМ")
+async def topup_sim_start_msg(message: types.Message, state: FSMContext):
+    user_id = message.from_user.id
+    if is_banned(user_id):
+        await message.answer("Вы забанены")
+        return
+    if not await is_subscribed(user_id):
+        await message.answer(
+            "Пожалуйста, подпишитесь на канал:", reply_markup=subscribe_keyboard()
+        )
+        return
+    if not is_topup_enabled():
+        await message.answer("Пополнения временно остановлены.")
+        return
+    ensure_user(user_id)
+    await message.answer("Введите ваш номер:")
+    await state.set_state(TopupSim.waiting_for_phone)
+
+
 @router.message(TopupSim.waiting_for_phone)
 async def process_phone(message: types.Message, state: FSMContext):
     await state.update_data(phone=message.text)
@@ -148,6 +167,25 @@ async def topup_balance_start(callback_query: types.CallbackQuery, state: FSMCon
     ensure_user(user_id)
     await callback_query.answer()
     await callback_query.message.answer("Введите сумму пополнения баланса (в $):")
+    await state.set_state(TopupBalance.waiting_for_amount)
+
+
+@router.message(F.text == "💰 Пополнить баланс")
+async def topup_balance_start_msg(message: types.Message, state: FSMContext):
+    user_id = message.from_user.id
+    if is_banned(user_id):
+        await message.answer("Вы забанены")
+        return
+    if not await is_subscribed(user_id):
+        await message.answer(
+            "Пожалуйста, подпишитесь на канал:", reply_markup=subscribe_keyboard()
+        )
+        return
+    if not is_topup_enabled():
+        await message.answer("Пополнения временно остановлены.")
+        return
+    ensure_user(user_id)
+    await message.answer("Введите сумму пополнения баланса (в $):")
     await state.set_state(TopupBalance.waiting_for_amount)
 
 

--- a/keyboards.py
+++ b/keyboards.py
@@ -1,4 +1,9 @@
-from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+from aiogram.types import (
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    KeyboardButton,
+    ReplyKeyboardMarkup,
+)
 
 from loader import CHANNEL_LINK
 
@@ -10,13 +15,13 @@ def subscribe_keyboard() -> InlineKeyboardMarkup:
     )
     return keyboard
 
-def main_menu() -> InlineKeyboardMarkup:
-    keyboard = InlineKeyboardMarkup(row_width=1)
+def main_menu() -> ReplyKeyboardMarkup:
+    keyboard = ReplyKeyboardMarkup(resize_keyboard=True)
     keyboard.add(
-        InlineKeyboardButton("👤 Мой профиль", callback_data="profile"),
-        InlineKeyboardButton("📱 Пополнить СИМ", callback_data="topup_sim"),
-        InlineKeyboardButton("💰 Пополнить баланс", callback_data="topup_balance"),
-        InlineKeyboardButton("📈 Актуальные курсы", callback_data="rates"),
+        KeyboardButton("📱 Пополнить СИМ"),
+        KeyboardButton("💰 Пополнить баланс"),
+        KeyboardButton("👤 Мой профиль"),
+        KeyboardButton("📈 Актуальные курсы"),
     )
     return keyboard
 
@@ -45,6 +50,7 @@ def admin_keyboard() -> InlineKeyboardMarkup:
         InlineKeyboardButton("📦 Все покупки", callback_data="admin_purchases"),
         InlineKeyboardButton("👥 Все пользователи", callback_data="admin_users"),
         InlineKeyboardButton("⛔ Остановить пополнения", callback_data="admin_topups"),
+        InlineKeyboardButton("💱 Установить курс", callback_data="admin_rate"),
     )
     return kb
 


### PR DESCRIPTION
## Summary
- Allow admins to set and store exchange rates
- Replace main menu with bottom reply buttons
- Add message handlers for new menu layout

## Testing
- `python -m py_compile db.py keyboards.py handlers/admin.py handlers/start.py handlers/topup.py`


------
https://chatgpt.com/codex/tasks/task_e_689f3b5c4ca4832b9641c111d4addef9