### PR TITLE
Switch to inline keyboards attached to messages

### DIFF
--- a/bot/handlers/menu.py
+++ b/bot/handlers/menu.py
@@ -1,5 +1,5 @@
 from aiogram import Router, F
-from aiogram.types import Message
+from aiogram.types import CallbackQuery
 
 from bot.keyboards import (
     ads_keyboard,
@@ -12,47 +12,52 @@ from bot.keyboards import (
 router = Router()
 
 
-@router.message(F.text == "Объявления")
-async def menu_ads(message: Message) -> None:
-    await message.answer("Раздел: объявления", reply_markup=ads_keyboard())
+@router.callback_query(F.data == "ads")
+async def menu_ads(callback: CallbackQuery) -> None:
+    await callback.message.edit_text("Раздел: объявления", reply_markup=ads_keyboard())
+    await callback.answer()
 
 
-@router.message(F.text == "Мой профиль")
-async def menu_profile(message: Message) -> None:
-    await message.answer("Раздел: мой профиль", reply_markup=profile_keyboard())
+@router.callback_query(F.data == "profile")
+async def menu_profile(callback: CallbackQuery) -> None:
+    await callback.message.edit_text("Раздел: мой профиль", reply_markup=profile_keyboard())
+    await callback.answer()
 
 
-@router.message(F.text == "Репутация")
-async def menu_reputation(message: Message) -> None:
-    await message.answer("Раздел: репутация", reply_markup=reputation_keyboard())
+@router.callback_query(F.data == "reputation")
+async def menu_reputation(callback: CallbackQuery) -> None:
+    await callback.message.edit_text("Раздел: репутация", reply_markup=reputation_keyboard())
+    await callback.answer()
 
 
-@router.message(F.text == "Помощь")
-async def menu_help(message: Message) -> None:
-    await message.answer("Раздел: помощь", reply_markup=help_keyboard())
+@router.callback_query(F.data == "help")
+async def menu_help(callback: CallbackQuery) -> None:
+    await callback.message.edit_text("Раздел: помощь", reply_markup=help_keyboard())
+    await callback.answer()
 
 
-@router.message(F.text == "⬅️ Назад")
-async def menu_back(message: Message) -> None:
-    await message.answer("Главное меню", reply_markup=main_keyboard())
+@router.callback_query(F.data == "back")
+async def menu_back(callback: CallbackQuery) -> None:
+    await callback.message.edit_text("Главное меню", reply_markup=main_keyboard())
+    await callback.answer()
 
 
-@router.message(
-    F.text.in_(
+@router.callback_query(
+    F.data.in_(
         {
-            "📌 Разместить объявление",
-            "🔍 Все объявления",
-            "🔔 Мои объявления",
-            "⭐ Репутация",
-            "👤 Моя статистика",
-            "⚙️ Настройки профиля",
-            "✅ Оставить отзыв",
-            "📊 Топ пользователей",
-            "📖 Правила площадки",
-            "❓ ЧАСТО ЗАДАВАЕМЫЕ ВОПРОСЫ",
-            "👨‍💻 Поддержка",
+            "post_ad",
+            "all_ads",
+            "my_ads",
+            "rep",
+            "stats",
+            "settings",
+            "leave_review",
+            "top_users",
+            "rules",
+            "faq",
+            "support",
         }
     )
 )
-async def menu_stub(message: Message) -> None:
-    await message.answer("Эта функция пока не реализована.")
+async def menu_stub(callback: CallbackQuery) -> None:
+    await callback.answer("Эта функция пока не реализована.")

--- a/bot/keyboards/default.py
+++ b/bot/keyboards/default.py
@@ -1,75 +1,68 @@
-"""Reply keyboards used across the bot.
+"""Inline keyboards used across the bot.
 
-This module previously relied on :class:`aiogram.types.ReplyKeyboardMarkup`
-to construct keyboards using the ``add`` method just like in aiogram v2.
-With aiogram v3 the ``ReplyKeyboardMarkup`` model is based on Pydantic and
-requires the ``keyboard`` field on creation. The old approach resulted in
-``ValidationError: Field required`` because we instantiated the markup
-without buttons and tried to add them afterwards.
-
-The fix is to utilise :class:`aiogram.utils.keyboard.ReplyKeyboardBuilder`
-which provides a convenient API for building keyboards and returns a
-properly initialised :class:`ReplyKeyboardMarkup` instance.
+Previously this module constructed ReplyKeyboardMarkup and sent them as
+persistent reply keyboards. To make buttons attached to messages we now
+use inline keyboards built with InlineKeyboardBuilder.
 """
 
-from aiogram.types import KeyboardButton, ReplyKeyboardMarkup
-from aiogram.utils.keyboard import ReplyKeyboardBuilder
+from aiogram.types import InlineKeyboardMarkup
+from aiogram.utils.keyboard import InlineKeyboardBuilder
 
 
-def main_keyboard() -> ReplyKeyboardMarkup:
-    """Create main reply keyboard with top level sections."""
+def main_keyboard() -> InlineKeyboardMarkup:
+    """Create main menu inline keyboard."""
 
-    builder = ReplyKeyboardBuilder()
-    builder.button(text="Объявления")
-    builder.button(text="Мой профиль")
-    builder.button(text="Репутация")
-    builder.button(text="Помощь")
+    builder = InlineKeyboardBuilder()
+    builder.button(text="Объявления", callback_data="ads")
+    builder.button(text="Мой профиль", callback_data="profile")
+    builder.button(text="Репутация", callback_data="reputation")
+    builder.button(text="Помощь", callback_data="help")
     builder.adjust(1)
-    return builder.as_markup(resize_keyboard=True)
+    return builder.as_markup()
 
 
-def ads_keyboard() -> ReplyKeyboardMarkup:
+def ads_keyboard() -> InlineKeyboardMarkup:
     """Keyboard for the "Объявления" section."""
 
-    builder = ReplyKeyboardBuilder()
-    builder.button(text="📌 Разместить объявление")
-    builder.button(text="🔍 Все объявления")
-    builder.button(text="🔔 Мои объявления")
-    builder.button(text="⬅️ Назад")
+    builder = InlineKeyboardBuilder()
+    builder.button(text="📌 Разместить объявление", callback_data="post_ad")
+    builder.button(text="🔍 Все объявления", callback_data="all_ads")
+    builder.button(text="🔔 Мои объявления", callback_data="my_ads")
+    builder.button(text="⬅️ Назад", callback_data="back")
     builder.adjust(1)
-    return builder.as_markup(resize_keyboard=True)
+    return builder.as_markup()
 
 
-def profile_keyboard() -> ReplyKeyboardMarkup:
+def profile_keyboard() -> InlineKeyboardMarkup:
     """Keyboard for the "Мой профиль" section."""
 
-    builder = ReplyKeyboardBuilder()
-    builder.button(text="⭐ Репутация")
-    builder.button(text="👤 Моя статистика")
-    builder.button(text="⚙️ Настройки профиля")
-    builder.button(text="⬅️ Назад")
+    builder = InlineKeyboardBuilder()
+    builder.button(text="⭐ Репутация", callback_data="rep")
+    builder.button(text="👤 Моя статистика", callback_data="stats")
+    builder.button(text="⚙️ Настройки профиля", callback_data="settings")
+    builder.button(text="⬅️ Назад", callback_data="back")
     builder.adjust(1)
-    return builder.as_markup(resize_keyboard=True)
+    return builder.as_markup()
 
 
-def reputation_keyboard() -> ReplyKeyboardMarkup:
+def reputation_keyboard() -> InlineKeyboardMarkup:
     """Keyboard for the "Репутация" section."""
 
-    builder = ReplyKeyboardBuilder()
-    builder.button(text="✅ Оставить отзыв")
-    builder.button(text="📊 Топ пользователей")
-    builder.button(text="⬅️ Назад")
+    builder = InlineKeyboardBuilder()
+    builder.button(text="✅ Оставить отзыв", callback_data="leave_review")
+    builder.button(text="📊 Топ пользователей", callback_data="top_users")
+    builder.button(text="⬅️ Назад", callback_data="back")
     builder.adjust(1)
-    return builder.as_markup(resize_keyboard=True)
+    return builder.as_markup()
 
 
-def help_keyboard() -> ReplyKeyboardMarkup:
+def help_keyboard() -> InlineKeyboardMarkup:
     """Keyboard for the "Помощь" section."""
 
-    builder = ReplyKeyboardBuilder()
-    builder.button(text="📖 Правила площадки")
-    builder.button(text="❓ ЧАСТО ЗАДАВАЕМЫЕ ВОПРОСЫ")
-    builder.button(text="👨‍💻 Поддержка")
-    builder.button(text="⬅️ Назад")
+    builder = InlineKeyboardBuilder()
+    builder.button(text="📖 Правила площадки", callback_data="rules")
+    builder.button(text="❓ ЧАСТО ЗАДАВАЕМЫЕ ВОПРОСЫ", callback_data="faq")
+    builder.button(text="👨‍💻 Поддержка", callback_data="support")
+    builder.button(text="⬅️ Назад", callback_data="back")
     builder.adjust(1)
-    return builder.as_markup(resize_keyboard=True)
+    return builder.as_markup()


### PR DESCRIPTION
## Summary
- convert reply keyboards into inline keyboards so buttons are attached to messages
- handle menu navigation via callback queries and edit texts

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a5b6a8efec832b94fe23e06ef2a57d