### PR TITLE
feat: add contact button for ads

### DIFF
--- a/bot/keyboards/__init__.py
+++ b/bot/keyboards/__init__.py
@@ -1,5 +1,5 @@
 from bot.keyboards.default import (
-    ad_manage_keyboard,
+    ad_view_keyboard,
     ads_keyboard,
     ads_list_keyboard,
     help_keyboard,
@@ -12,7 +12,7 @@ __all__ = [
     "main_keyboard",
     "ads_keyboard",
     "ads_list_keyboard",
-    "ad_manage_keyboard",
+    "ad_view_keyboard",
     "profile_keyboard",
     "reputation_keyboard",
     "help_keyboard",

--- a/bot/keyboards/default.py
+++ b/bot/keyboards/default.py
@@ -80,10 +80,15 @@ def ads_list_keyboard(ads: list[dict]) -> InlineKeyboardMarkup:
     return builder.as_markup()
 
 
-def ad_manage_keyboard(ad_id: int) -> InlineKeyboardMarkup:
-    """Keyboard with management actions for user's own ad."""
+def ad_view_keyboard(ad: dict, viewer_id: int) -> InlineKeyboardMarkup:
+    """Keyboard for a single advertisement with contact and edit options."""
 
     builder = InlineKeyboardBuilder()
-    builder.button(text="✏️ Изменить", callback_data=f"edit_ad:{ad_id}")
+    url = (
+        f"https://t.me/{ad['user_name']}" if ad.get("user_name") else f"tg://user?id={ad['user_id']}"
+    )
+    builder.button(text="📞 Связь", url=url)
+    if ad["user_id"] == viewer_id:
+        builder.button(text="✏️ Изменить", callback_data=f"edit_ad:{ad['id']}")
     builder.adjust(1)
     return builder.as_markup()


### PR DESCRIPTION
## Summary
- add inline contact button when viewing advertisements
- let users choose to hide their username when posting ads

## Testing
- `python -m py_compile bot/keyboards/default.py bot/keyboards/__init__.py bot/handlers/menu.py`

------
https://chatgpt.com/codex/tasks/task_e_68a5cd4b1df4832b9b511117d709ecaf