### PR TITLE
feat: add inline edit options for ads

### DIFF
--- a/bot/keyboards/__init__.py
+++ b/bot/keyboards/__init__.py
@@ -1,4 +1,5 @@
 from bot.keyboards.default import (
+    ad_edit_keyboard,
     ad_view_keyboard,
     ads_keyboard,
     ads_list_keyboard,
@@ -13,6 +14,7 @@ __all__ = [
     "ads_keyboard",
     "ads_list_keyboard",
     "ad_view_keyboard",
+    "ad_edit_keyboard",
     "profile_keyboard",
     "reputation_keyboard",
     "help_keyboard",

--- a/bot/keyboards/default.py
+++ b/bot/keyboards/default.py
@@ -92,3 +92,20 @@ def ad_view_keyboard(ad: dict, viewer_id: int) -> InlineKeyboardMarkup:
         builder.button(text="✏️ Изменить", callback_data=f"edit_ad:{ad['id']}")
     builder.adjust(1)
     return builder.as_markup()
+
+
+def ad_edit_keyboard(ad: dict) -> InlineKeyboardMarkup:
+    """Keyboard with buttons to edit advertisement fields."""
+
+    builder = InlineKeyboardBuilder()
+    builder.button(text="✏️ Название", callback_data=f"edit_field:title:{ad['id']}")
+    builder.button(text="📝 Описание", callback_data=f"edit_field:text:{ad['id']}")
+    builder.button(text="📷 Фото/Гиф", callback_data=f"edit_field:photo:{ad['id']}")
+    builder.button(text="🏷️ Теги", callback_data=f"edit_field:tags:{ad['id']}")
+    name_state = "Да" if ad.get("user_name") else "Нет"
+    builder.button(
+        text=f"👤 Имя: {name_state}", callback_data=f"toggle_name:{ad['id']}"
+    )
+    builder.button(text="✅ Готово", callback_data=f"edit_done:{ad['id']}")
+    builder.adjust(1)
+    return builder.as_markup()


### PR DESCRIPTION
## Summary
- add inline keyboard to update advertisement fields individually
- allow toggling username visibility from the edit menu

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a5d0b235a4832b852eb48437d3e76a